### PR TITLE
Add Linux ARM64 build to GitHub Actions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ windows-latest, ubuntu-20.04, macos-12, macos-14 ]
+        os: [ windows-latest, ubuntu-20.04, macos-12, macos-14, linux/arm64 ]
 
     runs-on: ${{ matrix.os }}
     name: Build on ${{ matrix.os }}
@@ -117,3 +117,13 @@ jobs:
           asset_path: artifact/jssh-darwin-arm64.zip
           asset_name: jssh-darwin-arm64.zip
           asset_content_type: application/zip
+
+      - name: Upload Release Asset for Linux ARM64 version
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifact/jssh-linux-arm64.tar.gz
+          asset_name: jssh-linux-arm64.tar.gz
+          asset_content_type: application/x-gzip

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## 安装
 
-安装预构建的版本（仅支持 Linux amd64、macOS amd64 和 Windows amd64 三种版本）：
+安装预构建的版本（仅支持 Linux amd64、Linux arm64、macOS amd64、macOS arm64 和 Windows amd64 五种版本）：
 
 [Releases 页面](https://github.com/leizongmin/jssh/releases)
 


### PR DESCRIPTION
Add support for building and releasing `linux arm64` binaries using GitHub Actions.

* **README.md**
  - Add `linux arm64` to the list of supported architectures in the "安装" section.

* **.github/workflows/build-release.yml**
  - Add `linux/arm64` to the matrix in the `build` job.
  - Add a step to upload the `linux arm64` binaries as release assets in the `release` job.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/leizongmin/jssh?shareId=5c01a782-ec8b-4ac4-86cc-79167989bf11).