### PR TITLE
Add Linux ARM64 build to GitHub Actions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -47,10 +47,41 @@ jobs:
           name: artifact-${{ matrix.os }}
           path: ./release/*.zip
 
+  build_linux_arm64:
+    runs-on: ubuntu-latest
+    name: Build on Linux ARM64
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v5
+        with:
+          go-version: ^1.22
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+
+      - name: Build on Linux ARM64
+        run: |
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          docker buildx create --use
+          docker buildx build --platform linux/arm64 -t jssh:linux-arm64 .
+          docker run --rm -v $(pwd)/release:/release jssh:linux-arm64 cp /path/to/binary /release/jssh-linux-arm64
+
+      - name: List files
+        run: ls -Rl release
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifact-linux-arm64
+          path: ./release/jssh-linux-arm64.tar.gz
+
   release:
     runs-on: ubuntu-latest
     name: Release
-    needs: [ build ]
+    needs: [ build, build_linux_arm64 ]
     steps:
 
       - name: Merge Artifacts
@@ -96,6 +127,16 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifact/jssh-linux-amd64.tar.gz
           asset_name: jssh-linux-amd64.tar.gz
+          asset_content_type: application/x-gzip
+
+      - name: Upload Release Asset for Linux ARM64 version
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifact/jssh-linux-arm64.tar.gz
+          asset_name: jssh-linux-arm64.tar.gz
           asset_content_type: application/x-gzip
 
       - name: Upload Release Asset for macOS AMD64 version

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -68,13 +68,13 @@ jobs:
         run: |
           make jsbuiltin
 
+      - name: Build on Linux riscv64
+        run: |
+          docker run --rm -v $(pwd):$(pwd) -w $(pwd) riscv64/golang bash -c "git config --global --add safe.directory /home/runner/work/jssh/jssh && go env && make jssh-only"
+
       - name: Build on Linux arm64
         run: |
           docker run --platform=arm64 --rm -v $(pwd):$(pwd) -w $(pwd) golang bash -c "git config --global --add safe.directory /home/runner/work/jssh/jssh && go env && make jssh-only"
-
-      - name: Build on Linux riscv64
-        run: |
-          docker run --platform=riscv64 --rm -v $(pwd):$(pwd) -w $(pwd) riscv64/golang bash -c "git config --global --add safe.directory /home/runner/work/jssh/jssh && go env && make jssh-only"
 
       - name: List files
         run: ls -Rl release

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -68,10 +68,6 @@ jobs:
         run: |
           make jsbuiltin
 
-      - name: Build on Linux riscv64
-        run: |
-          docker run --rm -v $(pwd):$(pwd) -w $(pwd) riscv64/golang:1.22-alpine bash -c "git config --global --add safe.directory /home/runner/work/jssh/jssh && go env && make jssh-only"
-
       - name: Build on Linux arm64
         run: |
           docker run --platform=arm64 --rm -v $(pwd):$(pwd) -w $(pwd) golang bash -c "git config --global --add safe.directory /home/runner/work/jssh/jssh && go env && make jssh-only"
@@ -144,16 +140,6 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifact/jssh-linux-arm64.tar.gz
           asset_name: jssh-linux-arm64.tar.gz
-          asset_content_type: application/x-gzip
-
-      - name: Upload Release Asset for Linux RISCV64 version
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: artifact/jssh-linux-riscv64.tar.gz
-          asset_name: jssh-linux-riscv64.tar.gz
           asset_content_type: application/x-gzip
 
       - name: Upload Release Asset for macOS AMD64 version

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -59,11 +59,17 @@ jobs:
         with:
           platforms: ${{ matrix.arch }}
 
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v5
+        with:
+          go-version: ^1.22
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
       - name: Build on Linux ${{ matrix.arch }}
         run: |
+          make jsbuiltin
           docker run --rm -v $(pwd):$(pwd) -w $(pwd) -e GOARCH=${{ matrix.arch }} golang bash -c "go env && make jssh"
 
       - name: List files

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Build on Linux ${{ matrix.arch }}
         run: |
           make jsbuiltin
-          docker run --rm -v $(pwd):$(pwd) -w $(pwd) -e GOARCH=${{ matrix.arch }} golang bash -c "go env && make jssh"
+          docker run --rm -v $(pwd):$(pwd) -w $(pwd) -e GOARCH=${{ matrix.arch }} golang bash -c "go env && make jssh-only"
 
       - name: List files
         run: ls -Rl release
@@ -140,6 +140,16 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifact/jssh-linux-arm64.tar.gz
           asset_name: jssh-linux-arm64.tar.gz
+          asset_content_type: application/x-gzip
+
+      - name: Upload Release Asset for Linux RISCV64 version
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifact/jssh-linux-riscv64.tar.gz
+          asset_name: jssh-linux-riscv64.tar.gz
           asset_content_type: application/x-gzip
 
       - name: Upload Release Asset for macOS AMD64 version

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -70,11 +70,11 @@ jobs:
 
       - name: Build on Linux arm64
         run: |
-          docker run --platform=arm64 --rm -v $(pwd):$(pwd) -w $(pwd) golang bash -c "go env && make jssh-only"
+          docker run --platform=arm64 --rm -v $(pwd):$(pwd) -w $(pwd) golang bash -c "git config --global --add safe.directory /home/runner/work/jssh/jssh && go env && make jssh-only"
 
       - name: Build on Linux riscv64
         run: |
-          docker run --platform=riscv64 --rm -v $(pwd):$(pwd) -w $(pwd) golang bash -c "go env && make jssh-only"
+          docker run --platform=riscv64 --rm -v $(pwd):$(pwd) -w $(pwd) riscv64/golang bash -c "git config --global --add safe.directory /home/runner/work/jssh/jssh && go env && make jssh-only"
 
       - name: List files
         run: ls -Rl release

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -47,27 +47,24 @@ jobs:
           name: artifact-${{ matrix.os }}
           path: ./release/*.zip
 
-  build_linux_arm64:
+  build_linux_other_platforms:
     runs-on: ubuntu-latest
-    name: Build on Linux ARM64
+    strategy:
+      matrix:
+        arch: [ arm64, riscv64 ]
+    name: Build on Linux ${{ matrix.arch }}
     steps:
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v5
+        uses: docker/setup-qemu-action@v3
         with:
-          go-version: ^1.22
+          platforms: ${{ matrix.arch }}
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Build on Linux ARM64
+      - name: Build on Linux ${{ matrix.arch }}
         run: |
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-          docker buildx create --use
-          docker buildx build --platform linux/arm64 -t jssh:linux-arm64 .
-          docker run --rm -v $(pwd)/release:/release jssh:linux-arm64 cp /path/to/binary /release/jssh-linux-arm64
+          docker run --rm -v $(pwd):$(pwd) -w $(pwd) -e GOARCH=${{ matrix.arch }} golang bash -c "go env && make jssh"
 
       - name: List files
         run: ls -Rl release
@@ -76,12 +73,12 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: artifact-linux-arm64
-          path: ./release/jssh-linux-arm64.tar.gz
+          path: ./release/*.tar.gz
 
   release:
     runs-on: ubuntu-latest
     name: Release
-    needs: [ build, build_linux_arm64 ]
+    needs: [ build, build_linux_other_platforms ]
     steps:
 
       - name: Merge Artifacts

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -49,15 +49,12 @@ jobs:
 
   build_linux_other_platforms:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [ arm64, riscv64 ]
-    name: Build on Linux ${{ matrix.arch }}
+    name: Build on Linux other platforms
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
-          platforms: ${{ matrix.arch }}
+          platforms: arm64,riscv64
 
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
@@ -67,10 +64,17 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Build on Linux ${{ matrix.arch }}
+      - name: Prepare build
         run: |
           make jsbuiltin
-          docker run --rm -v $(pwd):$(pwd) -w $(pwd) -e GOARCH=${{ matrix.arch }} golang bash -c "go env && make jssh-only"
+
+      - name: Build on Linux arm64
+        run: |
+          docker run --platform=arm64 --rm -v $(pwd):$(pwd) -w $(pwd) golang bash -c "go env && make jssh-only"
+
+      - name: Build on Linux riscv64
+        run: |
+          docker run --platform=riscv64 --rm -v $(pwd):$(pwd) -w $(pwd) golang bash -c "go env && make jssh-only"
 
       - name: List files
         run: ls -Rl release

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Build on Linux riscv64
         run: |
-          docker run --rm -v $(pwd):$(pwd) -w $(pwd) riscv64/golang bash -c "git config --global --add safe.directory /home/runner/work/jssh/jssh && go env && make jssh-only"
+          docker run --rm -v $(pwd):$(pwd) -w $(pwd) riscv64/golang:1.22-alpine bash -c "git config --global --add safe.directory /home/runner/work/jssh/jssh && go env && make jssh-only"
 
       - name: Build on Linux arm64
         run: |

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,12 @@ jssh: jsbuiltin
 	@ln -sf $(RELEASE_TARGET)/jssh release/jssh
 	@ls -alh release/*
 
+.PHONY: jssh-only
+jssh-only:
+	@go run . build.js
+	@ln -sf $(RELEASE_TARGET)/jssh release/jssh
+	@ls -alh release/*
+
 .PHONY: jssh_m
 jssh_m: jssh
 	@cp release/$(RELEASE_TARGET)/jssh release/$(RELEASE_TARGET)/jssh_m

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## 安装
 
-安装预构建的版本（仅支持 Linux amd64、macOS amd64 和 Windows amd64 三种版本）：
+安装预构建的版本（仅支持 Linux amd64、Linux arm64、macOS amd64、macOS arm64 和 Windows amd64 五种版本）：
 
 [Releases 页面](https://github.com/leizongmin/jssh/releases)
 


### PR DESCRIPTION
Add support for building and releasing `linux arm64` binaries using GitHub Actions.

* **README.md**
  - Add `linux arm64` to the list of supported architectures in the "安装" section.

* **.github/workflows/build-release.yml**
  - Add a new job `build_linux_arm64` to build `linux arm64` binaries using `docker/setup-qemu-action`.
  - Add steps to set up QEMU, set up Go, check out code, build the binary, list files, and upload the artifact.
  - Add a step to upload the `linux arm64` binaries as release assets in the `release` job.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/leizongmin/jssh?shareId=287be3a2-0894-4e4c-a3b4-a4de1bc7d1c3).